### PR TITLE
Prevent the code from generating null requests.

### DIFF
--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/panel/http/HttpCardSender.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/panel/http/HttpCardSender.java
@@ -46,7 +46,9 @@ public class HttpCardSender {
 
 	public void send() {
 		try {
-			executor.submit(new Request(new URL(DATA_URL_TEMPLATE), unsent));
+			if ( unsent.size() > 0 ) {
+				executor.submit(new Request(new URL(DATA_URL_TEMPLATE), unsent));
+			}
 		} catch (MalformedURLException e) {
 			e.printStackTrace();
 		} catch (RejectedExecutionException e) {


### PR DESCRIPTION
Checks unsent.size(), if it's 0, don't even spawn a request.
